### PR TITLE
fix render loop on follow card

### DIFF
--- a/app/Livewire/User/FollowCard.php
+++ b/app/Livewire/User/FollowCard.php
@@ -74,7 +74,7 @@ class FollowCard extends Component
      *
      * @var array<string, string>
      */
-    protected $listeners = ['refreshComponent' => '$refresh'];
+    protected $listeners = ['auth-follow-change' => '$refresh'];
 
     /**
      * The number of users being displayed.
@@ -136,21 +136,10 @@ class FollowCard extends Component
      */
     public function render(): View
     {
-        $this->followUsers = $this->profileUser->{$this->relationship}()->get();
-
-        return view('livewire.user.follow-card');
-    }
-
-    /**
-     * Called when the user follows or unfollows a user.
-     */
-    #[On('auth-follow-change')]
-    public function populateFollowUsers(): void
-    {
         // Update the collection of profile user's followers (or following).
         $this->followUsers = $this->profileUser->{$this->relationship}()->get();
 
-        $this->dispatch('refreshComponent');
+        return view('livewire.user.follow-card');
     }
 
     /**

--- a/app/Livewire/User/FollowCard.php
+++ b/app/Livewire/User/FollowCard.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
-use Livewire\Attributes\On;
 use Livewire\Component;
 
 class FollowCard extends Component

--- a/app/Livewire/User/FollowCard.php
+++ b/app/Livewire/User/FollowCard.php
@@ -136,7 +136,7 @@ class FollowCard extends Component
      */
     public function render(): View
     {
-        $this->populateFollowUsers();
+        $this->followUsers = $this->profileUser->{$this->relationship}()->get();
 
         return view('livewire.user.follow-card');
     }


### PR DESCRIPTION
fix #132

follow card was calling a function at render time that re-rendered itself from an event listener used to update the component on follow changes.

- replaced function call with a normal data assignment on render.
- removed unneeded function for event listener