### PR TITLE
feat: add search query parameter to mod filtering

### DIFF
--- a/app/Http/Controllers/Api/V0/ModController.php
+++ b/app/Http/Controllers/Api/V0/ModController.php
@@ -121,6 +121,7 @@ class ModController extends Controller
     #[UrlParam('filter[updated_between]', description: 'Filter by update date range (YYYY-MM-DD,YYYY-MM-DD).', required: false, example: '2025-01-01,2025-03-31')]
     #[UrlParam('filter[published_between]', description: 'Filter by publication date range (YYYY-MM-DD,YYYY-MM-DD).', required: false, example: '2025-01-01,2025-03-31')]
     #[UrlParam('filter[spt_version]', description: 'Filter mods that are compatible with an SPT version SemVer constraint. This will only filter the mods, not the mod versions.', required: false, example: '^3.8.0')]
+    #[UrlParam('query', description: 'Search query to filter mods using Meilisearch. This will search across name, slug, and description fields.', required: false, example: 'raid time')]
     #[UrlParam('include', description: 'Comma-separated list of relationships. Available: `owner`, `authors`, `versions`, `versions`, `license`.', required: false, example: 'owner,versions')]
     #[UrlParam('sort', description: 'Sort results by attribute(s). Default ASC. Prefix with `-` for DESC. Comma-separate multiple fields. Allowed: `id`, `name`, `slug`, `created_at`, `updated_at`, `published_at`.', required: false, example: '-created_at,name')]
     #[UrlParam('page', type: 'integer', description: 'The page number for pagination.', required: false, example: 2)]
@@ -131,7 +132,8 @@ class ModController extends Controller
             ->withFilters($request->input('filter'))
             ->withIncludes($request->string('include')->explode(',')->toArray())
             ->withFields($request->string('fields')->explode(',')->toArray())
-            ->withSorts($request->string('sort')->explode(',')->toArray());
+            ->withSorts($request->string('sort')->explode(',')->toArray())
+            ->withSearch($request->string('query')->toString());
 
         $mods = $queryBuilder->paginate($request->integer('per_page', 12));
 

--- a/app/Support/Api/V0/QueryBuilder/AbstractQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/AbstractQueryBuilder.php
@@ -129,7 +129,7 @@ abstract class AbstractQueryBuilder
      */
     protected function applySearch(): void
     {
-        if ($this->searchQuery === null) {
+        if (empty($this->searchQuery)) {
             return;
         }
 
@@ -148,9 +148,8 @@ abstract class AbstractQueryBuilder
         $searchResults = $model->search($this->searchQuery)->raw();
 
         if (empty($searchResults['hits'])) {
-            // If no search results, ensure no records are returned
+            // If no search results, force no records to be returned
             $this->builder->whereRaw('1 = 0');
-
             return;
         }
 
@@ -158,10 +157,9 @@ abstract class AbstractQueryBuilder
         /** @var list<int|string> $orderedIds */
         $orderedIds = collect($searchResults['hits'])->pluck('id')->all();
 
-        // If IDs array is empty after pluck (e.g., all hits lacked 'id'), prevent query errors
+        // If IDs array is empty after pluck (e.g., all hits lacked 'id'), force no records
         if (empty($orderedIds)) {
             $this->builder->whereRaw('1 = 0');
-
             return;
         }
 

--- a/app/Support/Api/V0/QueryBuilder/AbstractQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/AbstractQueryBuilder.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Laravel\Scout\Searchable;
 
 /**
  * @template TModel of Model
@@ -51,6 +52,11 @@ abstract class AbstractQueryBuilder
      * @var array<string, string>
      */
     protected array $sorts = [];
+
+    /**
+     * The search query to use with Scout.
+     */
+    protected ?string $searchQuery = null;
 
     /**
      * Create a new query builder instance.
@@ -113,8 +119,55 @@ abstract class AbstractQueryBuilder
         $this->applyIncludes();
         $this->applyFields();
         $this->applySorts();
+        $this->applySearch();
 
         return $this->builder;
+    }
+
+    /**
+     * Apply the search query using Scout if available.
+     */
+    protected function applySearch(): void
+    {
+        if ($this->searchQuery === null) {
+            return;
+        }
+
+        $modelClass = $this->getModelClass();
+        $model = new $modelClass;
+
+        if (! in_array(Searchable::class, class_uses_recursive($model), true)) {
+            // Model doesn't use Searchable trait, cannot perform Scout search.
+            return;
+        }
+
+        /** @phpstan-var TModel&Searchable $model */
+
+        // Get the search results with their relevance ordering
+        /** @phpstan-var array{hits: list<array{id: int|string, ...}>, ...} $searchResults */
+        $searchResults = $model->search($this->searchQuery)->raw();
+
+        if (empty($searchResults['hits'])) {
+            // If no search results, ensure no records are returned
+            $this->builder->whereRaw('1 = 0');
+
+            return;
+        }
+
+        // Get the IDs in the order they were returned from Scout
+        /** @var list<int|string> $orderedIds */
+        $orderedIds = collect($searchResults['hits'])->pluck('id')->all();
+
+        // If IDs array is empty after pluck (e.g., all hits lacked 'id'), prevent query errors
+        if (empty($orderedIds)) {
+            $this->builder->whereRaw('1 = 0');
+
+            return;
+        }
+
+        // Filter the main query by these IDs and preserve the order from Scout
+        $this->builder->whereIn($model->getQualifiedKeyName(), $orderedIds)
+            ->orderByRaw('FIELD('.$model->getQualifiedKeyName().', '.implode(',', array_map('intval', $orderedIds)).')');
     }
 
     /**
@@ -248,9 +301,8 @@ abstract class AbstractQueryBuilder
 
             foreach ($this->sorts as $sort) {
                 $isReverse = Str::startsWith($sort, '-');
-                $cleanName = $isReverse ? Str::substr($sort, 1) : $sort;
-                $direction = $isReverse ? 'desc' : 'asc';
-                $this->builder->orderBy($cleanName, $direction);
+                $column = $isReverse ? Str::substr($sort, 1) : $sort;
+                $this->builder->orderBy($column, $isReverse ? 'desc' : 'asc');
             }
         }
     }
@@ -259,11 +311,13 @@ abstract class AbstractQueryBuilder
      * Set the filters for the query.
      *
      * @param  array<string, mixed>|null  $filters
-     * @return $this
+     * @return self<TModel>
      */
     public function withFilters(?array $filters): self
     {
-        $this->filters = $filters ?? [];
+        if ($filters !== null) {
+            $this->filters = $filters;
+        }
 
         return $this;
     }
@@ -272,15 +326,12 @@ abstract class AbstractQueryBuilder
      * Set the includes for the query.
      *
      * @param  array<string>|null  $includes
-     * @return $this
+     * @return self<TModel>
      */
     public function withIncludes(?array $includes): self
     {
-        $this->includes = [];
-
         if ($includes !== null) {
-            // Filter out empty values and ensure all values are strings
-            $this->includes = array_filter($includes, fn ($include): bool => ! empty($include));
+            $this->includes = $includes;
         }
 
         return $this;
@@ -290,11 +341,13 @@ abstract class AbstractQueryBuilder
      * Set the fields for the query.
      *
      * @param  array<string>|null  $fields
-     * @return $this
+     * @return self<TModel>
      */
     public function withFields(?array $fields): self
     {
-        $this->fields = $fields ?? [];
+        if ($fields !== null) {
+            $this->fields = $fields;
+        }
 
         return $this;
     }
@@ -302,18 +355,34 @@ abstract class AbstractQueryBuilder
     /**
      * Set the sorts for the query.
      *
-     * @param  array<string, string>|null  $sorts
-     * @return $this
+     * @param  array<string>|null  $sorts
+     * @return self<TModel>
      */
     public function withSorts(?array $sorts): self
     {
-        $this->sorts = $sorts ?? [];
+        if ($sorts !== null) {
+            $this->sorts = $sorts;
+        }
 
         return $this;
     }
 
     /**
-     * Get the query results.
+     * Set the search query for the query.
+     *
+     * @return self<TModel>
+     */
+    public function withSearch(?string $query): self
+    {
+        if ($query !== null) {
+            $this->searchQuery = $query;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the results of the query.
      *
      * @return Collection<int, TModel>
      */
@@ -323,7 +392,7 @@ abstract class AbstractQueryBuilder
     }
 
     /**
-     * Get the paginated query results.
+     * Get the paginated results of the query.
      *
      * @return LengthAwarePaginator<int, TModel>
      */
@@ -335,6 +404,8 @@ abstract class AbstractQueryBuilder
     /**
      * Find a model by its primary key or throw an exception.
      *
+     * @return TModel
+     *
      * @throws ModelNotFoundException
      */
     public function findOrFail(int $id): Model
@@ -343,37 +414,31 @@ abstract class AbstractQueryBuilder
     }
 
     /**
-     * Parse a boolean input string to a boolean value.
+     * Parse a boolean input value.
      */
     protected static function parseBooleanInput(string $value): bool
     {
-        $value = Str::of($value)->trim()->lower()->toString();
-
-        // Truthy values
-        if (in_array($value, ['true', 'yes', 'on', '1'], true)) {
-            return true;
-        }
-
-        return false;
+        return in_array(strtolower($value), ['1', 'true', 'yes', 'on'], true);
     }
 
     /**
-     * Parse a comma-separated string to an array.
+     * Parse a comma-separated input value.
      *
-     * @param  'string'|'integer'  $castReturn
-     * @return array<int, string|int>
+     * @return array<mixed>
      */
     protected static function parseCommaSeparatedInput(string $value, ?string $castReturn = null): array
     {
-        return Str::of($value)
-            ->explode(',')
-            ->map(fn (string $value) => Str::trim($value))
-            ->filter()
-            ->map(fn (string $value): int|string => match ($castReturn) {
-                'string' => $value,
-                'integer' => (int) $value,
-                default => $value,
-            })
-            ->toArray();
+        $values = array_filter(explode(',', $value), fn ($value): bool => ! empty($value));
+
+        if ($castReturn === null) {
+            return $values;
+        }
+
+        return array_map(fn ($value): mixed => match ($castReturn) {
+            'integer' => (int) $value,
+            'float' => (float) $value,
+            'boolean' => self::parseBooleanInput($value),
+            default => $value,
+        }, $values);
     }
 }

--- a/tests/Feature/Api/V0/Mod/ModIndexTest.php
+++ b/tests/Feature/Api/V0/Mod/ModIndexTest.php
@@ -234,6 +234,18 @@ it('includes license relationship', function (): void {
     $response->assertJsonPath('data.0.license.id', $mod->license->id);
 });
 
+it('includes license relationship when a filter is applied', function (): void {
+    SptVersion::factory()->state(['version' => '3.8.0'])->create();
+
+    $mod = Mod::factory(['name' => 'MegaMod'])->hasVersions(1, ['spt_version_constraint' => '3.8.0'])->create();
+
+    $response = $this->withToken($this->token)->getJson('/api/v0/mods?filter[name]=MegaMod&include=license');
+
+    $response->assertStatus(Response::HTTP_OK);
+    $response->assertJsonStructure(['data' => ['*' => ['license' => ['id', 'name']]]]);
+    $response->assertJsonPath('data.0.license.id', $mod->license->id);
+});
+
 it('includes enabled mods with an enabled version', function (): void {
     SptVersion::factory()->state(['version' => '3.8.0'])->create();
 


### PR DESCRIPTION
Add a new search query parameter to the ModController to enable filtering of mods using Meilisearch. This allows users to search across the Mod models. Update the AbstractQueryBuilder to handle the search query and improve parameter handling for sorts and filters.