### PR TITLE
feat(import): add timestamps to license upsert process

### DIFF
--- a/app/Jobs/Import/ImportHubJob.php
+++ b/app/Jobs/Import/ImportHubJob.php
@@ -463,11 +463,13 @@ class ImportHubJob implements ShouldBeUnique, ShouldQueue
             'hub_id' => $hubModLicense->licenseID,
             'name' => $hubModLicense->licenseName,
             'link' => $hubModLicense->licenseURL,
+            'created_at' => Carbon::now('UTC')->toDateTimeString(),
+            'updated_at' => Carbon::now('UTC')->toDateTimeString(),
         ])->toArray();
 
-        // Upsert batch of users based on their hub_id.
+        // Upsert batch of licenses based on their hub_id.
         License::withoutEvents(function () use ($licenseData): void {
-            License::query()->upsert($licenseData, ['hub_id'], ['name', 'link']);
+            License::query()->upsert($licenseData, ['hub_id'], ['name', 'link', 'created_at', 'updated_at']);
         });
     }
 


### PR DESCRIPTION
Add 'created_at' and 'updated_at' fields to the license upsert operation in the ImportHubJob. This ensures that the license records have valid timestamps.

Resolves #176
