### PR TITLE
refactor: allow null values for filter parameters

### DIFF
--- a/app/Support/Api/V0/QueryBuilder/ModQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModQueryBuilder.php
@@ -87,46 +87,85 @@ class ModQueryBuilder extends AbstractQueryBuilder
     protected function getAllowedFilters(): array
     {
         return [
-            'id' => function (Builder $query, string $ids): void {
+            'id' => function (Builder $query, ?string $ids): void {
+                if ($ids === null) {
+                    return;
+                }
                 $query->whereIn('mods.id', self::parseCommaSeparatedInput($ids, 'integer'));
             },
-            'hub_id' => function (Builder $query, string $hubIds): void {
+            'hub_id' => function (Builder $query, ?string $hubIds): void {
+                if ($hubIds === null) {
+                    return;
+                }
                 $query->whereIn('mods.hub_id', self::parseCommaSeparatedInput($hubIds, 'integer'));
             },
-            'name' => function (Builder $query, string $term): void {
+            'name' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mods.name', sprintf('%%%s%%', $term));
             },
-            'slug' => function (Builder $query, string $term): void {
+            'slug' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mods.slug', sprintf('%%%s%%', $term));
             },
-            'teaser' => function (Builder $query, string $term): void {
+            'teaser' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mods.teaser', sprintf('%%%s%%', $term));
             },
-            'source_code_link' => function (Builder $query, string $term): void {
+            'source_code_link' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mods.source_code_link', sprintf('%%%s%%', $term));
             },
-            'featured' => function (Builder $query, string $value): void {
+            'featured' => function (Builder $query, ?string $value): void {
+                if ($value === null) {
+                    return;
+                }
                 $query->where('mods.featured', self::parseBooleanInput($value));
             },
-            'contains_ads' => function (Builder $query, string $value): void {
+            'contains_ads' => function (Builder $query, ?string $value): void {
+                if ($value === null) {
+                    return;
+                }
                 $query->where('mods.contains_ads', self::parseBooleanInput($value));
             },
-            'contains_ai_content' => function (Builder $query, string $value): void {
+            'contains_ai_content' => function (Builder $query, ?string $value): void {
+                if ($value === null) {
+                    return;
+                }
                 $query->where('mods.contains_ai_content', self::parseBooleanInput($value));
             },
-            'created_between' => function (Builder $query, string $range): void {
+            'created_between' => function (Builder $query, ?string $range): void {
+                if ($range === null) {
+                    return;
+                }
                 [$start, $end] = explode(',', $range);
                 $query->whereBetween('mods.created_at', [$start, $end]);
             },
-            'updated_between' => function (Builder $query, string $range): void {
+            'updated_between' => function (Builder $query, ?string $range): void {
+                if ($range === null) {
+                    return;
+                }
                 [$start, $end] = explode(',', $range);
                 $query->whereBetween('mods.updated_at', [$start, $end]);
             },
-            'published_between' => function (Builder $query, string $range): void {
+            'published_between' => function (Builder $query, ?string $range): void {
+                if ($range === null) {
+                    return;
+                }
                 [$start, $end] = explode(',', $range);
                 $query->whereBetween('mods.published_at', [$start, $end]);
             },
-            'spt_version' => function (Builder $query, string $version): void {
+            'spt_version' => function (Builder $query, ?string $version): void {
+                if ($version === null) {
+                    return;
+                }
                 $validSptVersions = SptVersion::allValidVersions();
                 $compatibleSptVersions = Semver::satisfiedBy($validSptVersions, $version);
                 $this->applySptVersionCondition($query, $compatibleSptVersions);

--- a/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
@@ -99,39 +99,69 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
     protected function getAllowedFilters(): array
     {
         return [
-            'id' => function (Builder $query, string $ids): void {
+            'id' => function (Builder $query, ?string $ids): void {
+                if ($ids === null) {
+                    return;
+                }
                 $query->whereIn('mod_versions.id', self::parseCommaSeparatedInput($ids, 'integer'));
             },
-            'hub_id' => function (Builder $query, string $hubIds): void {
+            'hub_id' => function (Builder $query, ?string $hubIds): void {
+                if ($hubIds === null) {
+                    return;
+                }
                 $query->whereIn('mod_versions.hub_id', self::parseCommaSeparatedInput($hubIds, 'integer'));
             },
-            'version' => function (Builder $query, string $semverConstraint): void {
+            'version' => function (Builder $query, ?string $semverConstraint): void {
+                if ($semverConstraint === null) {
+                    return;
+                }
                 $allVersionNumbers = ModVersion::versionNumbers($this->modId);
                 $compatibleVersions = Semver::satisfiedBy($allVersionNumbers, $semverConstraint);
                 $query->whereIn('mod_versions.version', $compatibleVersions);
             },
-            'description' => function (Builder $query, string $term): void {
+            'description' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mod_versions.description', sprintf('%%%s%%', $term));
             },
-            'link' => function (Builder $query, string $term): void {
+            'link' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mod_versions.link', sprintf('%%%s%%', $term));
             },
-            'virus_total_link' => function (Builder $query, string $term): void {
+            'virus_total_link' => function (Builder $query, ?string $term): void {
+                if ($term === null) {
+                    return;
+                }
                 $query->whereLike('mod_versions.virus_total_link', sprintf('%%%s%%', $term));
             },
-            'published_between' => function (Builder $query, string $range): void {
+            'published_between' => function (Builder $query, ?string $range): void {
+                if ($range === null) {
+                    return;
+                }
                 [$start, $end] = explode(',', $range);
                 $query->whereBetween('mod_versions.published_at', [$start, $end]);
             },
-            'created_between' => function (Builder $query, string $range): void {
+            'created_between' => function (Builder $query, ?string $range): void {
+                if ($range === null) {
+                    return;
+                }
                 [$start, $end] = explode(',', $range);
                 $query->whereBetween('mod_versions.created_at', [$start, $end]);
             },
-            'updated_between' => function (Builder $query, string $range): void {
+            'updated_between' => function (Builder $query, ?string $range): void {
+                if ($range === null) {
+                    return;
+                }
                 [$start, $end] = explode(',', $range);
                 $query->whereBetween('mod_versions.updated_at', [$start, $end]);
             },
-            'spt_version' => function (Builder $query, string $version): void {
+            'spt_version' => function (Builder $query, ?string $version): void {
+                if ($version === null) {
+                    return;
+                }
                 $validSptVersions = SptVersion::allValidVersions();
                 $compatibleSptVersions = Semver::satisfiedBy($validSptVersions, $version);
                 $this->applySptVersionCondition($query, $compatibleSptVersions);


### PR DESCRIPTION
Update filter functions in ModVersionQueryBuilder and ModQueryBuilder to accept nullable parameters. This change prevents unnecessary queries when filter values are null, improving query efficiency and ensuring better handling of optional filters.

Resolves #180