### PR TITLE
Better API Field Handling

### DIFF
--- a/app/Http/Controllers/Api/V0/ModController.php
+++ b/app/Http/Controllers/Api/V0/ModController.php
@@ -24,7 +24,7 @@ class ModController extends Controller
      *
      * Retrieves a paginated list of mods, allowing filtering, sorting, and relationship inclusion.
      *
-     * Fields available:<br /><code>id, hub_id, name, slug, teaser, thumbnail, downloads, source_code_link, featured,
+     * Fields available:<br /><code>hub_id, name, slug, teaser, thumbnail, downloads, source_code_link, featured,
      * contains_ai_content, contains_ads, published_at, created_at, updated_at</code>
      *
      * <aside class="notice">This endpoint only offers limited version information. Only the latest 6 versions will be
@@ -107,7 +107,7 @@ class ModController extends Controller
      *      "message": "Unauthenticated."
      *  }
      */
-    #[UrlParam('fields', description: 'Comma-separated list of fields to include in the response. Defaults to all fields.', required: false, example: 'id,name,slug,featured,created_at')]
+    #[UrlParam('fields', description: 'Comma-separated list of fields to include in the response. Defaults to all fields.', required: false, example: 'name,slug,featured,created_at')]
     #[UrlParam('filter[id]', description: 'Filter by comma-separated Mod IDs.', required: false, example: '1,5,10')]
     #[UrlParam('filter[hub_id]', description: 'Filter by comma-separated Hub IDs.', required: false, example: '123,456')]
     #[UrlParam('filter[name]', description: 'Filter by name (fuzzy filter).', required: false, example: 'Raid Time')]
@@ -145,7 +145,7 @@ class ModController extends Controller
      *
      * Retrieves details for a single mod, allowing relationship inclusion.
      *
-     * Fields available:<br /><code>id, hub_id, name, slug, teaser, description, thumbnail, downloads, source_code_link,
+     * Fields available:<br /><code>hub_id, name, slug, teaser, description, thumbnail, downloads, source_code_link,
      * featured, contains_ai_content, contains_ads, published_at, created_at, updated_at</code>
      *
      * <aside class="notice">This endpoint only offers limited version information. Only the latest 6 versions will be
@@ -179,7 +179,7 @@ class ModController extends Controller
      *      "message": "Resource not found."
      *  }
      */
-    #[UrlParam('fields', description: 'Comma-separated list of fields to include in the response. Defaults to all fields.', required: false, example: 'id,name,slug,featured,created_at')]
+    #[UrlParam('fields', description: 'Comma-separated list of fields to include in the response. Defaults to all fields.', required: false, example: 'name,slug,featured,created_at')]
     #[UrlParam('include', description: 'Comma-separated list of relationships. Available: `owner`, `authors`, `versions`, `license`.', required: false, example: 'owner,versions')]
     public function show(Request $request, int $modId): JsonResponse
     {

--- a/app/Http/Controllers/Api/V0/ModVersionController.php
+++ b/app/Http/Controllers/Api/V0/ModVersionController.php
@@ -22,7 +22,7 @@ class ModVersionController extends Controller
      *
      * Retrieves a paginated list of mod versions, allowing filtering, sorting, and relationship inclusion.
      *
-     * Fields available:<br /><code>id, hub_id, version, description, link, spt_version_constraint, virus_total_link,
+     * Fields available:<br /><code>hub_id, version, description, link, spt_version_constraint, virus_total_link,
      * downloads, published_at, created_at, updated_at</code>
      *
      * <aside class="notice">This endpoint only offers limited mod version dependency information. Only the immediate

--- a/app/Http/Resources/Api/V0/ModResource.php
+++ b/app/Http/Resources/Api/V0/ModResource.php
@@ -8,6 +8,7 @@ use App\Models\Mod;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
+use App\Support\Api\V0\QueryBuilder\ModQueryBuilder;
 use Override;
 
 /**
@@ -99,11 +100,11 @@ class ModResource extends JsonResource
         }
 
         if ($this->shouldInclude('created_at')) {
-            $data['created_at'] = $this->created_at->toISOString();
+            $data['created_at'] = $this->created_at?->toISOString();
         }
 
         if ($this->shouldInclude('updated_at')) {
-            $data['updated_at'] = $this->updated_at->toISOString();
+            $data['updated_at'] = $this->updated_at?->toISOString();
         }
 
         // Handle relationships separately... they're only included when loaded.
@@ -123,6 +124,10 @@ class ModResource extends JsonResource
      */
     protected function shouldInclude(string $field): bool
     {
-        return $this->showAllFields || in_array($field, $this->requestedFields, true);
+        $requiredFields = ModQueryBuilder::getRequiredFields();
+
+        return $this->showAllFields
+            || in_array($field, $this->requestedFields, true)
+            || in_array($field, $requiredFields, true);
     }
 }

--- a/app/Http/Resources/Api/V0/ModResource.php
+++ b/app/Http/Resources/Api/V0/ModResource.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V0;
 
 use App\Models\Mod;
+use App\Support\Api\V0\QueryBuilder\ModQueryBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
-use App\Support\Api\V0\QueryBuilder\ModQueryBuilder;
 use Override;
 
 /**

--- a/app/Http/Resources/Api/V0/ModVersionResource.php
+++ b/app/Http/Resources/Api/V0/ModVersionResource.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V0;
 
 use App\Models\ModVersion;
+use App\Support\Api\V0\QueryBuilder\ModVersionQueryBuilder;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
-use App\Support\Api\V0\QueryBuilder\ModVersionQueryBuilder;
 use Override;
 
 /**

--- a/app/Http/Resources/Api/V0/ModVersionResource.php
+++ b/app/Http/Resources/Api/V0/ModVersionResource.php
@@ -7,6 +7,7 @@ namespace App\Http\Resources\Api\V0;
 use App\Models\ModVersion;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Support\Api\V0\QueryBuilder\ModVersionQueryBuilder;
 use Override;
 
 /**
@@ -90,11 +91,11 @@ class ModVersionResource extends JsonResource
         }
 
         if ($this->shouldInclude('created_at')) {
-            $data['created_at'] = $this->resource->created_at->toISOString();
+            $data['created_at'] = $this->resource->created_at?->toISOString();
         }
 
         if ($this->shouldInclude('updated_at')) {
-            $data['updated_at'] = $this->resource->updated_at->toISOString();
+            $data['updated_at'] = $this->resource->updated_at?->toISOString();
         }
 
         $data['dependencies'] = new ModResolvedDependencyCollection(
@@ -112,6 +113,10 @@ class ModVersionResource extends JsonResource
      */
     protected function shouldInclude(string $field): bool
     {
-        return $this->showAllFields || in_array($field, $this->requestedFields, true);
+        $requiredFields = ModVersionQueryBuilder::getRequiredFields();
+
+        return $this->showAllFields
+            || in_array($field, $this->requestedFields, true)
+            || in_array($field, $requiredFields, true);
     }
 }

--- a/app/Models/ModVersion.php
+++ b/app/Models/ModVersion.php
@@ -41,8 +41,8 @@ use Override;
  * @property int $downloads
  * @property bool $disabled
  * @property Carbon|null $published_at
- * @property Carbon $created_at
- * @property Carbon $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read Mod $mod
  * @property-read Collection<int, ModDependency> $dependencies
  * @property-read Collection<int, ModVersion> $resolvedDependencies

--- a/app/Support/Api/V0/QueryBuilder/AbstractQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/AbstractQueryBuilder.php
@@ -203,7 +203,8 @@ abstract class AbstractQueryBuilder
         }
 
         foreach ($this->filters as $filter => $value) {
-            $allowedFilters[$filter]->bindTo($this)($this->builder, $value);
+            $method = $allowedFilters[$filter];
+            $this->{$method}($this->builder, $value);
         }
     }
 

--- a/app/Support/Api/V0/QueryBuilder/ModQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModQueryBuilder.php
@@ -43,8 +43,6 @@ class ModQueryBuilder extends AbstractQueryBuilder
     protected function applySptVersionCondition(Builder $query, ?array $compatibleVersions = null): void
     {
         $query->whereExists(function ($query) use ($compatibleVersions): void {
-
-            // By default, get all mods that have at least one version that is compatible with the SPT version
             $query->select(DB::raw(1))
                 ->from('mod_versions')
                 ->join('mod_version_spt_version', 'mod_versions.id', '=', 'mod_version_spt_version.mod_version_id')
@@ -84,7 +82,7 @@ class ModQueryBuilder extends AbstractQueryBuilder
      *
      * @return array<string, callable>
      */
-    protected function getAllowedFilters(): array
+    public static function getAllowedFilters(): array
     {
         return [
             'id' => function (Builder $query, ?string $ids): void {
@@ -187,17 +185,31 @@ class ModQueryBuilder extends AbstractQueryBuilder
     }
 
     /**
-     * Get the map of API include names to model relationship names.
+     * Get the allowed relationships that can be included.
      *
-     * @return array<string, string>
+     * @return array<string>
      */
-    protected function getAllowedIncludes(): array
+    public static function getAllowedIncludes(): array
     {
         return [
-            'owner' => 'owner',
-            'authors' => 'authors',
-            'versions' => 'versions',
-            'license' => 'license',
+            'owner',
+            'authors',
+            'versions',
+            'license',
+        ];
+    }
+
+    /**
+     * Get the required fields that should always be loaded for relationships.
+     *
+     * @return array<string>
+     */
+    public static function getRequiredFields(): array
+    {
+        return [
+            'id',
+            'owner_id',
+            'license_id',
         ];
     }
 
@@ -206,10 +218,9 @@ class ModQueryBuilder extends AbstractQueryBuilder
      *
      * @return array<string>
      */
-    protected function getAllowedFields(): array
+    public static function getAllowedFields(): array
     {
         return [
-            'id',
             'hub_id',
             'name',
             'slug',
@@ -232,7 +243,7 @@ class ModQueryBuilder extends AbstractQueryBuilder
      *
      * @return array<string>
      */
-    protected function getAllowedSorts(): array
+    public static function getAllowedSorts(): array
     {
         return [
             'id',

--- a/app/Support/Api/V0/QueryBuilder/ModQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModQueryBuilder.php
@@ -80,108 +80,212 @@ class ModQueryBuilder extends AbstractQueryBuilder
     /**
      * Get the allowed filters for this query builder.
      *
-     * @return array<string, callable>
+     * @return array<string, string>
      */
     public static function getAllowedFilters(): array
     {
         return [
-            'id' => function (Builder $query, ?string $ids): void {
-                if ($ids === null) {
-                    return;
-                }
-
-                $query->whereIn('mods.id', self::parseCommaSeparatedInput($ids, 'integer'));
-            },
-            'hub_id' => function (Builder $query, ?string $hubIds): void {
-                if ($hubIds === null) {
-                    return;
-                }
-
-                $query->whereIn('mods.hub_id', self::parseCommaSeparatedInput($hubIds, 'integer'));
-            },
-            'name' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mods.name', sprintf('%%%s%%', $term));
-            },
-            'slug' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mods.slug', sprintf('%%%s%%', $term));
-            },
-            'teaser' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mods.teaser', sprintf('%%%s%%', $term));
-            },
-            'source_code_link' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mods.source_code_link', sprintf('%%%s%%', $term));
-            },
-            'featured' => function (Builder $query, ?string $value): void {
-                if ($value === null) {
-                    return;
-                }
-
-                $query->where('mods.featured', self::parseBooleanInput($value));
-            },
-            'contains_ads' => function (Builder $query, ?string $value): void {
-                if ($value === null) {
-                    return;
-                }
-
-                $query->where('mods.contains_ads', self::parseBooleanInput($value));
-            },
-            'contains_ai_content' => function (Builder $query, ?string $value): void {
-                if ($value === null) {
-                    return;
-                }
-
-                $query->where('mods.contains_ai_content', self::parseBooleanInput($value));
-            },
-            'created_between' => function (Builder $query, ?string $range): void {
-                if ($range === null) {
-                    return;
-                }
-
-                [$start, $end] = explode(',', $range);
-                $query->whereBetween('mods.created_at', [$start, $end]);
-            },
-            'updated_between' => function (Builder $query, ?string $range): void {
-                if ($range === null) {
-                    return;
-                }
-
-                [$start, $end] = explode(',', $range);
-                $query->whereBetween('mods.updated_at', [$start, $end]);
-            },
-            'published_between' => function (Builder $query, ?string $range): void {
-                if ($range === null) {
-                    return;
-                }
-
-                [$start, $end] = explode(',', $range);
-                $query->whereBetween('mods.published_at', [$start, $end]);
-            },
-            'spt_version' => function (Builder $query, ?string $version): void {
-                if ($version === null) {
-                    return;
-                }
-
-                $validSptVersions = SptVersion::allValidVersions();
-                $compatibleSptVersions = Semver::satisfiedBy($validSptVersions, $version);
-                $this->applySptVersionCondition($query, $compatibleSptVersions);
-            },
+            'id' => 'filterById',
+            'hub_id' => 'filterByHubId',
+            'name' => 'filterByName',
+            'slug' => 'filterBySlug',
+            'teaser' => 'filterByTeaser',
+            'source_code_link' => 'filterBySourceCodeLink',
+            'featured' => 'filterByFeatured',
+            'contains_ads' => 'filterByContainsAds',
+            'contains_ai_content' => 'filterByContainsAiContent',
+            'created_between' => 'filterByCreatedBetween',
+            'updated_between' => 'filterByUpdatedBetween',
+            'published_between' => 'filterByPublishedBetween',
+            'spt_version' => 'filterBySptVersion',
         ];
+    }
+
+    /**
+     * Filter by mod IDs.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterById(Builder $query, ?string $ids): void
+    {
+        if ($ids === null) {
+            return;
+        }
+
+        $query->whereIn('mods.id', self::parseCommaSeparatedInput($ids, 'integer'));
+    }
+
+    /**
+     * Filter by hub IDs.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByHubId(Builder $query, ?string $hubIds): void
+    {
+        if ($hubIds === null) {
+            return;
+        }
+
+        $query->whereIn('mods.hub_id', self::parseCommaSeparatedInput($hubIds, 'integer'));
+    }
+
+    /**
+     * Filter by name.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByName(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mods.name', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by slug.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterBySlug(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mods.slug', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by teaser.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByTeaser(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mods.teaser', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by source code link.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterBySourceCodeLink(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mods.source_code_link', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by featured status.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByFeatured(Builder $query, ?string $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        $query->where('mods.featured', self::parseBooleanInput($value));
+    }
+
+    /**
+     * Filter by contains ads status.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByContainsAds(Builder $query, ?string $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        $query->where('mods.contains_ads', self::parseBooleanInput($value));
+    }
+
+    /**
+     * Filter by contains AI content status.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByContainsAiContent(Builder $query, ?string $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        $query->where('mods.contains_ai_content', self::parseBooleanInput($value));
+    }
+
+    /**
+     * Filter by creation date range.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByCreatedBetween(Builder $query, ?string $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        [$start, $end] = explode(',', $range);
+        $query->whereBetween('mods.created_at', [$start, $end]);
+    }
+
+    /**
+     * Filter by update date range.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByUpdatedBetween(Builder $query, ?string $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        [$start, $end] = explode(',', $range);
+        $query->whereBetween('mods.updated_at', [$start, $end]);
+    }
+
+    /**
+     * Filter by publication date range.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterByPublishedBetween(Builder $query, ?string $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        [$start, $end] = explode(',', $range);
+        $query->whereBetween('mods.published_at', [$start, $end]);
+    }
+
+    /**
+     * Filter by SPT version.
+     *
+     * @param  Builder<Mod>  $query
+     */
+    protected function filterBySptVersion(Builder $query, ?string $version): void
+    {
+        if ($version === null) {
+            return;
+        }
+
+        $validSptVersions = SptVersion::allValidVersions();
+        $compatibleSptVersions = Semver::satisfiedBy($validSptVersions, $version);
+        $this->applySptVersionCondition($query, $compatibleSptVersions);
     }
 
     /**

--- a/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
@@ -277,7 +277,7 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
                 return; // All sorts were empty and filtered out, return early.
             }
 
-            $allowedSorts = $this->getAllowedSorts();
+            $allowedSorts = static::getAllowedSorts();
             $invalidSorts = [];
 
             foreach ($this->sorts as $sort) {

--- a/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
@@ -93,89 +93,170 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
     /**
      * Get the allowed filters for this query builder.
      *
-     * @return array<string, callable>
+     * @return array<string, string>
      */
     public static function getAllowedFilters(): array
     {
         return [
-            'id' => function (Builder $query, ?string $ids): void {
-                if ($ids === null) {
-                    return;
-                }
-
-                $query->whereIn('mod_versions.id', self::parseCommaSeparatedInput($ids, 'integer'));
-            },
-            'hub_id' => function (Builder $query, ?string $hubIds): void {
-                if ($hubIds === null) {
-                    return;
-                }
-
-                $query->whereIn('mod_versions.hub_id', self::parseCommaSeparatedInput($hubIds, 'integer'));
-            },
-            'version' => function (Builder $query, ?string $semverConstraint): void {
-                if ($semverConstraint === null) {
-                    return;
-                }
-
-                $allVersionNumbers = ModVersion::versionNumbers($this->modId);
-                $compatibleVersions = Semver::satisfiedBy($allVersionNumbers, $semverConstraint);
-                $query->whereIn('mod_versions.version', $compatibleVersions);
-            },
-            'description' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mod_versions.description', sprintf('%%%s%%', $term));
-            },
-            'link' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mod_versions.link', sprintf('%%%s%%', $term));
-            },
-            'virus_total_link' => function (Builder $query, ?string $term): void {
-                if ($term === null) {
-                    return;
-                }
-
-                $query->whereLike('mod_versions.virus_total_link', sprintf('%%%s%%', $term));
-            },
-            'published_between' => function (Builder $query, ?string $range): void {
-                if ($range === null) {
-                    return;
-                }
-
-                [$start, $end] = explode(',', $range);
-                $query->whereBetween('mod_versions.published_at', [$start, $end]);
-            },
-            'created_between' => function (Builder $query, ?string $range): void {
-                if ($range === null) {
-                    return;
-                }
-
-                [$start, $end] = explode(',', $range);
-                $query->whereBetween('mod_versions.created_at', [$start, $end]);
-            },
-            'updated_between' => function (Builder $query, ?string $range): void {
-                if ($range === null) {
-                    return;
-                }
-
-                [$start, $end] = explode(',', $range);
-                $query->whereBetween('mod_versions.updated_at', [$start, $end]);
-            },
-            'spt_version' => function (Builder $query, ?string $version): void {
-                if ($version === null) {
-                    return;
-                }
-
-                $validSptVersions = SptVersion::allValidVersions();
-                $compatibleSptVersions = Semver::satisfiedBy($validSptVersions, $version);
-                $this->applySptVersionCondition($query, $compatibleSptVersions);
-            },
+            'id' => 'filterById',
+            'hub_id' => 'filterByHubId',
+            'version' => 'filterByVersion',
+            'description' => 'filterByDescription',
+            'link' => 'filterByLink',
+            'virus_total_link' => 'filterByVirusTotalLink',
+            'published_between' => 'filterByPublishedBetween',
+            'created_between' => 'filterByCreatedBetween',
+            'updated_between' => 'filterByUpdatedBetween',
+            'spt_version' => 'filterBySptVersion',
         ];
+    }
+
+    /**
+     * Filter by mod version IDs.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterById(Builder $query, ?string $ids): void
+    {
+        if ($ids === null) {
+            return;
+        }
+
+        $query->whereIn('mod_versions.id', self::parseCommaSeparatedInput($ids, 'integer'));
+    }
+
+    /**
+     * Filter by hub IDs.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByHubId(Builder $query, ?string $hubIds): void
+    {
+        if ($hubIds === null) {
+            return;
+        }
+
+        $query->whereIn('mod_versions.hub_id', self::parseCommaSeparatedInput($hubIds, 'integer'));
+    }
+
+    /**
+     * Filter by version.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByVersion(Builder $query, ?string $semverConstraint): void
+    {
+        if ($semverConstraint === null) {
+            return;
+        }
+
+        $allVersionNumbers = ModVersion::versionNumbers($this->modId);
+        $compatibleVersions = Semver::satisfiedBy($allVersionNumbers, $semverConstraint);
+        $query->whereIn('mod_versions.version', $compatibleVersions);
+    }
+
+    /**
+     * Filter by description.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByDescription(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mod_versions.description', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by link.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByLink(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mod_versions.link', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by VirusTotal link.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByVirusTotalLink(Builder $query, ?string $term): void
+    {
+        if ($term === null) {
+            return;
+        }
+
+        $query->whereLike('mod_versions.virus_total_link', sprintf('%%%s%%', $term));
+    }
+
+    /**
+     * Filter by publication date range.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByPublishedBetween(Builder $query, ?string $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        [$start, $end] = explode(',', $range);
+        $query->whereBetween('mod_versions.published_at', [$start, $end]);
+    }
+
+    /**
+     * Filter by creation date range.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByCreatedBetween(Builder $query, ?string $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        [$start, $end] = explode(',', $range);
+        $query->whereBetween('mod_versions.created_at', [$start, $end]);
+    }
+
+    /**
+     * Filter by update date range.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterByUpdatedBetween(Builder $query, ?string $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        [$start, $end] = explode(',', $range);
+        $query->whereBetween('mod_versions.updated_at', [$start, $end]);
+    }
+
+    /**
+     * Filter by SPT version.
+     *
+     * @param  Builder<ModVersion>  $query
+     */
+    protected function filterBySptVersion(Builder $query, ?string $version): void
+    {
+        if ($version === null) {
+            return;
+        }
+
+        $validSptVersions = SptVersion::allValidVersions();
+        $compatibleSptVersions = Semver::satisfiedBy($validSptVersions, $version);
+
+        $this->applySptVersionCondition($query, $compatibleSptVersions);
     }
 
     /**
@@ -190,21 +271,6 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
                 'resolvedDependencies',
                 'resolvedDependencies.mod',
             ],
-        ];
-    }
-
-    /**
-     * Get the required fields that should always be loaded for relationships.
-     * These fields are not subject to field whitelisting and will be automatically included when needed.
-     *
-     * @return array<string>
-     */
-    public static function getRequiredFields(): array
-    {
-        return [
-            'id',
-            'mod_id',
-            'version',
         ];
     }
 

--- a/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
+++ b/app/Support/Api/V0/QueryBuilder/ModVersionQueryBuilder.php
@@ -38,7 +38,6 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
     protected function getBaseQuery(): Builder
     {
         $query = ModVersion::query()
-            ->select('mod_versions.*')
             ->whereModId($this->modId)
             ->where('mod_versions.disabled', false);
 
@@ -96,7 +95,7 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
      *
      * @return array<string, callable>
      */
-    protected function getAllowedFilters(): array
+    public static function getAllowedFilters(): array
     {
         return [
             'id' => function (Builder $query, ?string $ids): void {
@@ -184,7 +183,7 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
      *
      * @return array<string, string|array<string>>
      */
-    protected function getAllowedIncludes(): array
+    public static function getAllowedIncludes(): array
     {
         return [
             'dependencies' => [
@@ -195,11 +194,41 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
     }
 
     /**
+     * Get the required fields that should always be loaded for relationships.
+     * These fields are not subject to field whitelisting and will be automatically included when needed.
+     *
+     * @return array<string>
+     */
+    public static function getRequiredFields(): array
+    {
+        return [
+            'id',
+            'mod_id',
+            'version',
+        ];
+    }
+
+    /**
+     * Get the required fields that should always be loaded for relationships.
+     * These fields are not subject to field whitelisting and will be automatically included when needed.
+     *
+     * @return array<string>
+     */
+    public static function getRequiredFields(): array
+    {
+        return [
+            'id',
+            'mod_id',
+            'version',
+        ];
+    }
+
+    /**
      * Get the allowed fields for this query builder.
      *
      * @return array<string>
      */
-    protected function getAllowedFields(): array
+    public static function getAllowedFields(): array
     {
         return [
             'id',
@@ -221,7 +250,7 @@ class ModVersionQueryBuilder extends AbstractQueryBuilder
      *
      * @return array<string>
      */
-    protected function getAllowedSorts(): array
+    public static function getAllowedSorts(): array
     {
         return [
             'id',

--- a/tests/Feature/Api/V0/Mod/ModIndexTest.php
+++ b/tests/Feature/Api/V0/Mod/ModIndexTest.php
@@ -186,6 +186,7 @@ it('sorts mods by created_at descending', function (): void {
     $modMid = Mod::factory()->hasVersions(1, ['spt_version_constraint' => '3.8.0'])->create(['created_at' => now()->subDay()]);
 
     $response = $this->withToken($this->token)->getJson('/api/v0/mods?sort=-created_at');
+
     $response->assertStatus(Response::HTTP_OK)->assertJsonCount(3, 'data');
     $response->assertJsonPath('data.0.id', $modNew->id);
     $response->assertJsonPath('data.1.id', $modMid->id);
@@ -244,6 +245,17 @@ it('includes license relationship when a filter is applied', function (): void {
     $response->assertStatus(Response::HTTP_OK);
     $response->assertJsonStructure(['data' => ['*' => ['license' => ['id', 'name']]]]);
     $response->assertJsonPath('data.0.license.id', $mod->license->id);
+});
+
+it('includes a relationship when fields are specified', function (): void {
+    SptVersion::factory()->state(['version' => '3.8.0'])->create();
+
+    $mod = Mod::factory()->hasVersions(1, ['spt_version_constraint' => '3.8.0'])->create();
+
+    $response = $this->withToken($this->token)->getJson('/api/v0/mods?fields=id,name&include=owner');
+
+    $response->assertStatus(Response::HTTP_OK);
+    $response->assertJsonStructure(['data' => ['*' => ['id', 'name', 'owner' => ['id', 'name']]]]);
 });
 
 it('includes enabled mods with an enabled version', function (): void {
@@ -403,7 +415,13 @@ it('returns only the fields requested', function (): void {
 
     $mod = Mod::factory()->hasVersions(1, ['spt_version_constraint' => '3.8.0'])->create();
 
-    $response = $this->withToken($this->token)->getJson('/api/v0/mods?fields=id,name');
+    $response = $this->withToken($this->token)->getJson('/api/v0/mods?fields=name');
 
-    $response->assertOk()->assertJsonStructure(['data' => ['*' => ['id', 'name']]]);
+    $response->assertOk();
+
+    // Assert that the id (required) and name (requested) fields are present
+    $response->assertJsonStructure(['data' => ['*' => ['id', 'name']]]);
+
+    // Assert that the created_at and updated_at fields are not present
+    $response->assertJsonMissing(['data' => ['*' => ['created_at', 'updated_at']]]);
 });


### PR DESCRIPTION
- Made getAllowedFilters() and getAllowedSorts() static for consistent static access  
- Ensured required fields are always included in ModVersionResource output  
- Added null-safe checks for created_at and updated_at in ModResource  
- Updated API docs to remove deprecated 'id' field from available fields list  
- Enhanced ModIndexTest to verify presence of required fields and omission of optional fields

Resolves #184