### PR TITLE
Fixing workbreak for links and long words

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -73,7 +73,7 @@ button {
 
 .user-markdown {
     a {
-        @apply underline text-black dark:text-white hover:text-cyan-800 hover:dark:text-cyan-200 transition-colors;
+        @apply underline text-black dark:text-white hover:text-cyan-800 hover:dark:text-cyan-200 transition-colors break-all;
     }
 
     b, strong {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -113,7 +113,7 @@ button {
     }
 
     p {
-        @apply my-2 text-gray-800 dark:text-gray-300;
+        @apply my-2 text-gray-800 dark:text-gray-300 wrap-anywhere;
     }
 
     hr {


### PR DESCRIPTION
Will fix word break for longer links and break everywhere and will fix breaking longer "non-link" words.

Before
![firefox_wh9CPEmL5X](https://github.com/user-attachments/assets/11984acb-3f38-46f9-9029-4c2790a1b5b6)
After
![firefox_BD2dSsEyww](https://github.com/user-attachments/assets/9343aee9-a5a0-458e-99e2-671bbf24d9d7)


Fix #215 
