### PR TITLE
add cursor-pointer to mobile theme controls

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -176,9 +176,9 @@
             <div class="flex justify-center px-5">
                 {{-- Mobile Theme Toggle --}}
                 <flux:radio.group x-data="" variant="segmented" x-model="$flux.appearance">
-                    <flux:radio value="light" icon="sun" />
-                    <flux:radio value="dark" icon="moon" />
-                    <flux:radio value="system" icon="computer-desktop" />
+                    <flux:radio class="cursor-pointer" value="light" icon="sun" />
+                    <flux:radio class="cursor-pointer" value="dark" icon="moon" />
+                    <flux:radio class="cursor-pointer" value="system" icon="computer-desktop" />
                 </flux:radio.group>
             </div>
         </div>


### PR DESCRIPTION
just adds the pointer class to the mobile theme controls for consistency with the desktop dropdown controls

related to #244 