### PR TITLE
Fix: Mod version alignment

### DIFF
--- a/resources/views/components/mod/version-card.blade.php
+++ b/resources/views/components/mod/version-card.blade.php
@@ -18,7 +18,7 @@
 
         <div class="flex flex-col items-start sm:flex-row sm:justify-between">
             <div class="flex flex-col">
-                <a href="{{ $version->downloadUrl() }}" class=" text-3xl font-extrabold text-gray-800 hover:text-black dark:text-gray-200 dark:hover:text-white" rel="nofollow">
+                <a href="{{ $version->downloadUrl() }}" class="text-3xl font-extrabold text-gray-800 hover:text-black dark:text-gray-200 dark:hover:text-white" rel="nofollow">
                     {{ __('Version') }} {{ $version->version }}
                     <flux:tooltip content="Download Mod Version" position="right">
                         <flux:icon icon="arrow-down-on-square-stack" class="inline-block size-6 ml-2 relative -top-1" />

--- a/resources/views/components/mod/version-card.blade.php
+++ b/resources/views/components/mod/version-card.blade.php
@@ -18,7 +18,7 @@
 
         <div class="flex flex-col items-start sm:flex-row sm:justify-between">
             <div class="flex flex-col">
-                <a href="{{ $version->downloadUrl() }}" class="self-center text-3xl font-extrabold text-gray-800 hover:text-black dark:text-gray-200 dark:hover:text-white" rel="nofollow">
+                <a href="{{ $version->downloadUrl() }}" class=" text-3xl font-extrabold text-gray-800 hover:text-black dark:text-gray-200 dark:hover:text-white" rel="nofollow">
                     {{ __('Version') }} {{ $version->version }}
                     <flux:tooltip content="Download Mod Version" position="right">
                         <flux:icon icon="arrow-down-on-square-stack" class="inline-block size-6 ml-2 relative -top-1" />
@@ -38,7 +38,7 @@
                             @endif
                         </p>
                     </flux:tooltip>
-                    <p class="ml-2.5 self-center text-sm text-gray-800 dark:text-gray-300" title="{{ __('Exactly') }} {{ $version->downloads }}">
+                    <p class="ml-2.5 text-sm text-gray-800 dark:text-gray-300" title="{{ __('Exactly') }} {{ $version->downloads }}">
                         {{ Number::downloads($version->downloads) }} {{ __('Downloads') }}
                     </p>
                 </div>


### PR DESCRIPTION
The anchor element had the class "self-center" causing the issue, removing it fixed it

**Before:**
<img width="753" height="258" alt="image" src="https://github.com/user-attachments/assets/642f96b8-182c-40f4-94fb-560e97565977" />

**After:**
<img width="750" height="244" alt="image" src="https://github.com/user-attachments/assets/1fdd4e2b-0491-4620-b0d7-de2298ea5514" />
