### PR TITLE
feat: add latest mod version badge

### DIFF
--- a/resources/views/components/mod/card.blade.php
+++ b/resources/views/components/mod/card.blade.php
@@ -41,7 +41,11 @@
             <div class="flex flex-col w-full justify-between p-5">
                 <div class="pb-3">
                     <h3 class="my-1 text-lg leading-tight font-medium text-black dark:text-white group-hover:underline">
-                        {{ $mod->name }}</h3>
+                        {{ $mod->name }}
+                        <span class="font-light text-nowrap text-gray-600 dark:text-gray-400">
+                            {{ $version->version }}
+                        </span>
+                    </h3>
                     <p class="no-underline mb-2 text-sm italic text-slate-600 dark:text-gray-200">
                         {{ __('Created by :owner', ['owner' => $mod->owner?->name ?? '']) }}
                     </p>


### PR DESCRIPTION
_Resolves https://github.com/sp-tarkov/forge/issues/374_

---

<details>

<summary>
old proposal
</summary>

### Before

<img width="2370" height="1471" alt="image" src="https://github.com/user-attachments/assets/69f2e142-1714-4ff6-8fb2-fd8a17b03133" />


### After

<img width="2374" height="1428" alt="image" src="https://github.com/user-attachments/assets/92b13500-e6b1-4192-a07a-d25e65c5bd9d" />

---

I placed the latest mod version next to the SPT version, just with de-emphasised styling. This makes sure that the latest mod version is visible, but IMO doesn't the mod card feel too cluttered.

</details>


### Before

<img width="2370" height="1471" alt="image" src="https://github.com/user-attachments/assets/69f2e142-1714-4ff6-8fb2-fd8a17b03133" />


### After

<img width="2376" height="1533" alt="image" src="https://github.com/user-attachments/assets/6036cd17-ceb3-47de-a9cd-29e092a7e258" />

The solution was voted for in the https://github.com/sp-tarkov/forge/pull/428#issuecomment-3622693197 comment.