### PR TITLE
fix(style): set classes statically

### DIFF
--- a/resources/views/components/tab-button.blade.php
+++ b/resources/views/components/tab-button.blade.php
@@ -3,9 +3,9 @@
     :aria-selected="selectedTab == '{{ $tabValue }}'"
     :class="{
         'font-extrabold': selectedTab == '{{ $tabValue }}',
-        'font-light': selectedTab != '{{ $tabValue }}',
-        'tab group relative min-w-0 flex-1 overflow-hidden py-4 px-4 text-center text-sm text-gray-800 dark:text-white bg-cyan-500 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 focus:z-10 last:rounded-r-xl first:rounded-l-xl flex items-center justify-center gap-1': true
+        'font-light': selectedTab != '{{ $tabValue }}'
     }"
+    class="tab group relative min-w-0 flex-1 overflow-hidden py-4 px-4 text-center text-sm text-gray-800 dark:text-white bg-cyan-500 dark:bg-cyan-700 hover:bg-cyan-400 dark:hover:bg-cyan-600 focus:z-10 last:rounded-r-xl first:rounded-l-xl flex items-center justify-center gap-1"
     {{ $attributes }}
 >
     {{ __($displayLabel) }}


### PR DESCRIPTION
> [!WARNING]
> **FLASHING GIFS!!!**

---

## Problem

When loading the mod page, the tab navbar isn't initially styled, leading to a layout shift:

![Screen Recording 2025-12-07 at 19 30 25](https://github.com/user-attachments/assets/c919e0f0-321c-485d-8320-1793fdbb8807)


## Solution

The important layout related classes should be placed inside of the `class` attribute, so that we don't have to wait for JavaScript to load, in order to resolve it. After the change, the loading looks like so:

![Screen Recording 2025-12-07 at 19 33 44](https://github.com/user-attachments/assets/f2932641-00ed-465f-a0cd-47bd6036ba9d)
