### PR TITLE
improve "download latest vsersion" light & dark text color contrast

### DIFF
--- a/resources/views/components/mod/download-button.blade.php
+++ b/resources/views/components/mod/download-button.blade.php
@@ -14,7 +14,7 @@
 <div class="{{ $name === 'download-show-mobile' ? 'lg:hidden block' : 'hidden lg:block' }}">
     <flux:modal.trigger name="{{ $name }}">
         <button
-            class="text-lg font-extrabold hover:bg-cyan-400 dark:hover:bg-cyan-600 shadow-md dark:shadow-gray-950 drop-shadow-2xl bg-cyan-500 dark:bg-cyan-700 rounded-xl w-full h-20"
+            class="text-lg font-extrabold text-gray-800 dark:text-white hover:bg-cyan-400 dark:hover:bg-cyan-600 shadow-md dark:shadow-gray-950 drop-shadow-2xl bg-cyan-500 dark:bg-cyan-700 rounded-xl w-full h-20"
         >
             <div class="flex flex-col justify-center items-center">
                 <div>{{ __('Download Latest Version') }} ({{ $versionString }})</div>


### PR DESCRIPTION
_related to https://github.com/sp-tarkov/forge/issues/30_

---

### Before

> light

<img width="643" height="186" alt="image" src="https://github.com/user-attachments/assets/c9e9b1e9-025a-40b1-b6d7-26f9bca11f29" />

> dark

<img width="669" height="223" alt="image" src="https://github.com/user-attachments/assets/06045931-2b1c-4dca-9e28-cf762805f842" />

### After 

> light

<img width="653" height="228" alt="image" src="https://github.com/user-attachments/assets/c12a9ac8-51a7-476a-86ac-a49cc220008a" />

> dark

<img width="666" height="234" alt="image" src="https://github.com/user-attachments/assets/3622e87f-15a1-4f1a-b059-823f1cfa38c0" />

The foreground contrast of the "Download Latest Version (x.x.x)" button is quite poor, especially on the light theme. I reused the same colors as the ones used for the tab buttons of the mod page, as they are at least AA WCAG compliant.
